### PR TITLE
Feature/habitat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ celerybeat-schedule
 venv/
 ENV/
 
+# habitat packages
+results/

--- a/etp_api/__init__.py
+++ b/etp_api/__init__.py
@@ -3,6 +3,8 @@ from flask_sqlalchemy import SQLAlchemy
 from flask.ext.heroku import Heroku
 
 app = Flask(__name__)
+# set this deprecated variable to false to reduce overhead
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 heroku = Heroku(app)
 db = SQLAlchemy(app)

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,1 +1,1 @@
-listening_port=8000
+listening_port=8080

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,0 +1,1 @@
+listening_port=8000

--- a/habitat/hooks/init
+++ b/habitat/hooks/init
@@ -1,0 +1,8 @@
+#!/bin/sh -xe
+
+# Allows to see errors as they occur
+exec 2>&1
+
+ln -fs {{pkg.path}}/etp_api {{pkg.svc_var_path}}
+ln -fs {{pkg.path}}/venv {{pkg.svc_var_path}}
+ln -fs {{pkg.path}}/*.py {{pkg.svc_var_path}}

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -6,6 +6,5 @@ exec 2>&1
 cd {{pkg.svc_var_path}}
 source venv/bin/activate
 
-# start the server
-build_line "Serving the wsgi with gunicorn ..."
-gunicorn wsgi
+# start the server using gunicorn
+gunicorn wsgi --bind 0.0.0.0:8080

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -1,0 +1,11 @@
+#!/bin/sh -xe
+
+# Allows to see errors as they occur
+exec 2>&1
+
+cd {{pkg.svc_var_path}}
+source venv/bin/activate
+
+# start the server
+build_line "Serving the wsgi with gunicorn ..."
+gunicorn wsgi

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -41,8 +41,8 @@ do_install() {
   build_line "Creating a virtual environment ..."
   virtualenv venv -p python3
   source venv/bin/activate
-  build_line "Installing requirements from requirements.txt ..."
+  build_line "Installing psycopg2 without binaries ..."
   pip install --no-binary :all: psycopg2
+  build_line "Installing requirements from requirements.txt ..."
   pip install -r requirements.txt
-  build_line "Done installing requirements ..."
 }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,46 @@
+pkg_origin=gitgik
+pkg_name=etp-api
+pkg_version=0.1.0
+pkg_maintainer="jee@brighthive.io, stanley@brighthive.io, aretha@brighthive.io"
+pkg_upstream_url="https://github.com/workforce-data-initiative/etp-api.git"
+pkg_exports=([port]=listening_port)
+pkg_exposes=(port)
+pkg_build_deps=(core/virtualenv)
+pkg_deps=(core/python core/coreutils)
+pkg_interpreters=(bin/python3)
+pkg_licence=('MIT')
+
+do_verify () {
+  return 0
+}
+
+do_clean() {
+  return 0
+}
+
+do_unpack() {
+  # copy the contents of the source directory to the habitat cache path
+  PROJECT_ROOT="${PLAN_CONTEXT}/.."
+
+  mkdir -p $pkg_prefix
+  build_line "Copying project data /src to $pkg_prefix/ ..."
+  cp -r $PROJECT_ROOT/etp_api $pkg_prefix/
+  cp -r $PROJECT_ROOT/tests $pkg_prefix/
+  cp -r $PROJECT_ROOT/*.py $pkg_prefix/
+  cp -r $PROJECT_ROOT/requirements.txt $pkg_prefix/
+  build_line "Copying .env file with preset variables ..."
+}
+
+do_build() {
+  pip install --upgrade pip
+}
+
+do_install() {
+  cd $pkg_prefix
+  build_line "Creating virtual environment ..."
+  virtualenv venv
+  source venv/bin/activate
+  build_line "Installing requirements from requirements.txt ..."
+  pip install -r requirements.txt
+  build_line "Done installing requirements ..."
+}

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -2,10 +2,11 @@ pkg_origin=brighthive
 pkg_name=etp-api
 pkg_version=0.1.0
 pkg_maintainer="jee@brighthive.io, stanley@brighthive.io, aretha@brighthive.io"
+pkg_filename=${pkg_name}-${pkg_version}.tar.gz
 pkg_upstream_url="https://github.com/workforce-data-initiative/etp-api.git"
 pkg_exports=([port]=listening_port)
 pkg_exposes=(port)
-pkg_build_deps=(core/virtualenv)
+pkg_build_deps=(core/virtualenv core/postgresql core/gcc)
 pkg_deps=(core/python core/coreutils)
 pkg_interpreters=(bin/python3)
 pkg_licence=('MIT')
@@ -19,28 +20,29 @@ do_clean() {
 }
 
 do_unpack() {
-  # copy the contents of the source directory to the habitat cache path
+  # create a env variable for the project root
   PROJECT_ROOT="${PLAN_CONTEXT}/.."
 
   mkdir -p $pkg_prefix
+  # copy the contents of the source directory to the habitat cache path
   build_line "Copying project data /src to $pkg_prefix ..."
   cp -r $PROJECT_ROOT/etp_api $pkg_prefix/
   cp -r $PROJECT_ROOT/tests $pkg_prefix/
   cp -r $PROJECT_ROOT/*.py $pkg_prefix/
   cp -r $PROJECT_ROOT/requirements.txt $pkg_prefix/
-  build_line "Copying .env file with preset variables ..."
 }
 
 do_build() {
-  pip install --upgrade pip
+  return 0
 }
 
 do_install() {
   cd $pkg_prefix
-  build_line "Creating virtual environment ..."
-  virtualenv venv
+  build_line "Creating a virtual environment ..."
+  virtualenv venv -p python3
   source venv/bin/activate
   build_line "Installing requirements from requirements.txt ..."
+  pip install --no-binary :all: psycopg2
   pip install -r requirements.txt
   build_line "Done installing requirements ..."
 }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,4 +1,4 @@
-pkg_origin=gitgik
+pkg_origin=brighthive
 pkg_name=etp-api
 pkg_version=0.1.0
 pkg_maintainer="jee@brighthive.io, stanley@brighthive.io, aretha@brighthive.io"
@@ -23,7 +23,7 @@ do_unpack() {
   PROJECT_ROOT="${PLAN_CONTEXT}/.."
 
   mkdir -p $pkg_prefix
-  build_line "Copying project data /src to $pkg_prefix/ ..."
+  build_line "Copying project data /src to $pkg_prefix ..."
   cp -r $PROJECT_ROOT/etp_api $pkg_prefix/
   cp -r $PROJECT_ROOT/tests $pkg_prefix/
   cp -r $PROJECT_ROOT/*.py $pkg_prefix/

--- a/results/last_build.env
+++ b/results/last_build.env
@@ -1,8 +1,8 @@
 pkg_origin=brighthive
 pkg_name=etp-api
 pkg_version=0.1.0
-pkg_release=20170608173001
-pkg_ident=brighthive/etp-api/0.1.0/20170608173001
-pkg_artifact=brighthive-etp-api-0.1.0-20170608173001-x86_64-linux.hart
-pkg_sha256sum=63d83dab32a8b69dc4bb2805a887bb13e1e063d589b664c75b7c86df0840763f
-pkg_blake2bsum=9de8b7abc34c7d4bb16322a6fd0739e4cc5b5691f8dc2c5dc95786d31d11712b
+pkg_release=20170609105751
+pkg_ident=brighthive/etp-api/0.1.0/20170609105751
+pkg_artifact=brighthive-etp-api-0.1.0-20170609105751-x86_64-linux.hart
+pkg_sha256sum=1d1d7bc59beb391bbde50eee3760ad864c3ff2bb449a0321326e8dc12bc941d7
+pkg_blake2bsum=b39395bd5ed5c5299cae7b537d332ceb910a3569bb225ede07e05c9b26914cbc

--- a/results/last_build.env
+++ b/results/last_build.env
@@ -1,8 +1,8 @@
 pkg_origin=brighthive
 pkg_name=etp-api
 pkg_version=0.1.0
-pkg_release=20170609105751
-pkg_ident=brighthive/etp-api/0.1.0/20170609105751
-pkg_artifact=brighthive-etp-api-0.1.0-20170609105751-x86_64-linux.hart
-pkg_sha256sum=1d1d7bc59beb391bbde50eee3760ad864c3ff2bb449a0321326e8dc12bc941d7
-pkg_blake2bsum=b39395bd5ed5c5299cae7b537d332ceb910a3569bb225ede07e05c9b26914cbc
+pkg_release=20170615123933
+pkg_ident=brighthive/etp-api/0.1.0/20170615123933
+pkg_artifact=brighthive-etp-api-0.1.0-20170615123933-x86_64-linux.hart
+pkg_sha256sum=f33e1aab949cce35f2482acf97e4dce76cc2a2b79be5a8a0ccf9e215f040d971
+pkg_blake2bsum=4ea404e1017f01af176f5450bb2df9ee5ca7f236b815a6b6c0f3dcd130a161a6

--- a/results/last_build.env
+++ b/results/last_build.env
@@ -1,0 +1,8 @@
+pkg_origin=brighthive
+pkg_name=etp-api
+pkg_version=0.1.0
+pkg_release=20170608173001
+pkg_ident=brighthive/etp-api/0.1.0/20170608173001
+pkg_artifact=brighthive-etp-api-0.1.0-20170608173001-x86_64-linux.hart
+pkg_sha256sum=63d83dab32a8b69dc4bb2805a887bb13e1e063d589b664c75b7c86df0840763f
+pkg_blake2bsum=9de8b7abc34c7d4bb16322a6fd0739e4cc5b5691f8dc2c5dc95786d31d11712b

--- a/run.py
+++ b/run.py
@@ -1,7 +1,7 @@
 from etp_api import app
 import os
 
-port = os.environ.get('PORT', 5002)
+port = os.environ.get('PORT', 8080)
 try:
     port = int(port)
     app.run(debug=True, host='localhost', port=port)


### PR DESCRIPTION
#### What does this PR do?
It defines a habitat plan that creates a habitat package for the etp-api service

#### Description of the Task
**Acceptance Criteria**
GIVEN I have an ETP API Service
WHEN I want to package it
THEN I can create a habitat package to bundle the whole API service 
The package should then be exportable to be deployed either on a virtual server or a PaaS

#### How should this be manually tested?
Habitat's purpose is to bundle up a service with its runtime and dependencies and metadata into a format that can run anywhere.

To test out the ETP API habitat package, do the following:
* download and install and configure [habitat](https://www.habitat.sh/docs/get-habitat/) on your test machine.
* Create a habitat origin (and name it `brighthive`) using the habitat setup command
    ```bash
    $ hab setup
    ```
* cd into the repo directory and start the habitat studio
    ```bash
    $ cd etp-api
    $ hab studio enter
    ```
    You'll enter an isolated environment for building the package.
* Build the habitat package using the build command:
    ```bash
    [1][default:/src:1]\# build
    ```
    After a successful build, you'll notice an autogenerated `/results` folder containing the resultant package(.hart). This is the habitat package that can now be exported to be run anywhere.

* Export it to any format, docker ACI or even a tarball!
    ```bash
    [2][default:/src:1]# hab pkg export docker brighthive/etp-api
    ```
* Exit the hab studio setup by typing `exit`
* Run the exported docker image 
    ```bash
    $ docker run -it -p 8080:8080 brighthive/etp-api
    ```
#### Relevant Pivotal Tracker stories?
#146449635
