### PR TITLE
Feature/habitat

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,46 @@ Run the `deploy.sh` and enter the right information for Heroku username and pass
 ./deploy.sh
 ```
 
+### 6. Automating deployment using habitat
+
+[Habitat](https://www.habitat.sh/) helps package an app or service into containers that can be run in any infrastructure, without committing to a specific container format or platform.
+
+#### Installing habitat
+To install habitat, simply download the binary.
+* Unzip `hab` into `/usr/local/bin`
+* Run `sudo chmod a+x hab` to make it executable.
+* You'll also need docker installed if on Mac. Find docker [here](https://store.docker.com/editions/community/docker-ce-desktop-mac)
+* To confirm if habitat is installed, re-open your terminal and type `hab` then press enter. You should see a list menu with all the habitat options available. Moving on swiftly!
+
+
+#### Setup a habitat origin
+* Run `hab setup` and set the origin name to **`brighthive`**.
+* Go to Settings on your github account and create a Personal Access Token under Developer Settings. Here's a link to get you [there](https://github.com/settings/tokens/new).
+
+The GitHub personal access token needs information provided from the `user:email` and `read:org` OAuth scopes. Habitat uses the information provided through these scopes for authentication and to determine features based on team membership.
+
+This is how it should look like when running the setup:
+<img width="636" alt="screenshot 2017-07-28 18 18 26" src="https://user-images.githubusercontent.com/15085180/28724015-5ac259ca-73c1-11e7-9eda-94e1fe74b3f2.png">
+
+
+#### Running etp-api using habitat
+* Cd into the repo's directory
+```bash
+cd etp-api
+```
+
+* Enter the habitat studio
+```bash
+hab studio enter
+```
+This is an awesome isolated environment for building great things so that when building, it doesn't affect anything on your computer.
+Let's go ahead and build the etp-api!
+
+* Inside the studio, run the `build` command to execute the etp-api plan
+```bash
+[5][default:/src:0]# build
+```
+
 License
 -------
 This project is licensed under the MIT License - see the `LICENSE.md` file for details.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ Let's go ahead and build the etp-api!
 When finished building, you should see this message
 `etp-api: I love it when a plan.sh comes together.`
 
+The build bundles up the etp-api source code, dependencies, runtime and other server configurations into a habitat .hart package. This package can now be exported to docker.
+
+In linux environments, the package can then be run directly using this simple command:
+```bash
+$ hab start brighthive/etp-api
+```
+
 #### Exporting to docker
 You can export the created .hart package into a docker container using the `hab pkg export docker` command as follows:
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ Let's go ahead and build the etp-api!
 ```bash
 [5][default:/src:0]# build
 ```
+When finished building, you should see this message
+`etp-api: I love it when a plan.sh comes together.`
+
+#### Exporting to docker
+You can export the created .hart package into a docker container using the `hab pkg export docker` command as follows:
+
+```bash
+[5][default:/src:0]# hab pkg export docker brighthive/etp-api
+```
+
+#### All systems go!
+After exiting the studio by typing `exit`, run the docker container as follows:
+
+```bash
+$ docker run -it -p 8080:8080 brighthive/etp-api
+```
+We're cooking with gas! 🔥 🚀
 
 License
 -------

--- a/habitat/hooks/init
+++ b/habitat/hooks/init
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/bash -xe
 
 # Allows to see errors as they occur
 exec 2>&1

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/bash -xe
 
 # Allows to see errors as they occur
 exec 2>&1

--- a/results/last_build.env
+++ b/results/last_build.env
@@ -1,8 +1,8 @@
 pkg_origin=brighthive
 pkg_name=etp-api
 pkg_version=0.1.0
-pkg_release=20170714114057
-pkg_ident=brighthive/etp-api/0.1.0/20170714114057
-pkg_artifact=brighthive-etp-api-0.1.0-20170714114057-x86_64-linux.hart
-pkg_sha256sum=16a694c18870eff44a4d2f4f491df432057cc5970110dfe710f9d15302dbb147
-pkg_blake2bsum=6449e49527d6d54b0472f57f34cf094f4cca2c905cd8e4b4ae770f171a1488c3
+pkg_release=20170721172333
+pkg_ident=brighthive/etp-api/0.1.0/20170721172333
+pkg_artifact=brighthive-etp-api-0.1.0-20170721172333-x86_64-linux.hart
+pkg_sha256sum=395710ee6acdb63488f51c12ad3222ab5f227ab1ead9f8e992419d5124d9a476
+pkg_blake2bsum=f797b6c106b0c59ec39a8caaa9d0152092443a2d351807c9965a957b5702f9de

--- a/results/last_build.env
+++ b/results/last_build.env
@@ -1,8 +1,8 @@
 pkg_origin=brighthive
 pkg_name=etp-api
 pkg_version=0.1.0
-pkg_release=20170713205745
-pkg_ident=brighthive/etp-api/0.1.0/20170713205745
-pkg_artifact=brighthive-etp-api-0.1.0-20170713205745-x86_64-linux.hart
-pkg_sha256sum=b903c84d7f61d54c3721ffc6b737d9ed4d5075fc3211ae875cba83e88dbf7895
-pkg_blake2bsum=7d65f8c3c69e3d4f62ffdc84fcbae17faa27d2b57468f4f073f0849627472e86
+pkg_release=20170714114057
+pkg_ident=brighthive/etp-api/0.1.0/20170714114057
+pkg_artifact=brighthive-etp-api-0.1.0-20170714114057-x86_64-linux.hart
+pkg_sha256sum=16a694c18870eff44a4d2f4f491df432057cc5970110dfe710f9d15302dbb147
+pkg_blake2bsum=6449e49527d6d54b0472f57f34cf094f4cca2c905cd8e4b4ae770f171a1488c3

--- a/results/last_build.env
+++ b/results/last_build.env
@@ -1,8 +1,8 @@
 pkg_origin=brighthive
 pkg_name=etp-api
 pkg_version=0.1.0
-pkg_release=20170615123933
-pkg_ident=brighthive/etp-api/0.1.0/20170615123933
-pkg_artifact=brighthive-etp-api-0.1.0-20170615123933-x86_64-linux.hart
-pkg_sha256sum=f33e1aab949cce35f2482acf97e4dce76cc2a2b79be5a8a0ccf9e215f040d971
-pkg_blake2bsum=4ea404e1017f01af176f5450bb2df9ee5ca7f236b815a6b6c0f3dcd130a161a6
+pkg_release=20170713205745
+pkg_ident=brighthive/etp-api/0.1.0/20170713205745
+pkg_artifact=brighthive-etp-api-0.1.0-20170713205745-x86_64-linux.hart
+pkg_sha256sum=b903c84d7f61d54c3721ffc6b737d9ed4d5075fc3211ae875cba83e88dbf7895
+pkg_blake2bsum=7d65f8c3c69e3d4f62ffdc84fcbae17faa27d2b57468f4f073f0849627472e86


### PR DESCRIPTION
#### What does this PR do?
It defines the documentation on how to install and configure habitat and how to use it to automate etp-api service.

#### Description of the Task
The readme was updated to reflect the instructions need to configure habitat in a local system, build and run the etp-api server and finally export the create .hart package to a docker container 

#### How should this be manually tested?
Follow the habitat instructions in the readme.MD to test on local machine