### PR TITLE
Add abacus-tpot to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
+abacus-tpot
+faker
 Flask==0.10.1
-gunicorn==19.7.0
 flask-restplus
 flask-sqlalchemy
 flask-heroku
-psycopg2
+gunicorn==19.7.0
 numpy
 pandas
-faker
+psycopg2


### PR DESCRIPTION
#### What does this PR do?
Adds abacus-tpot to `requirements.txt` so that during build the latest version of https://github.com/workforce-data-initiative/tpot-abacus is installed.